### PR TITLE
This fixes issue #1

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var gutil = require('gulp-util');
 var through = require('through2');
 
 function relPath(base, filePath) {
-  var newPath = filePath.replace(base, '');
+  var newPath = filePath.replace(base, '').replace(new RegExp(path.sep, 'g'),'/');
   if (filePath !== newPath && newPath[0] === path.sep) {
     return newPath.substr(1);
   } else {


### PR DESCRIPTION
Issue: if running under windows, the search pattern (e.g. "css\min.css") will not match text to be replaced (e.g."css/min.css"). This fix assumes that no one will be using windows-style patterns on the URLs.
