### PR TITLE
Perform replacements in all files, including reved ones

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,21 @@
+{
+  "node": true,
+  "browser": false,
+  "esnext": true,
+  "bitwise": true,
+  "camelcase": true,
+  "curly": true,
+  "eqeqeq": true,
+  "immed": true,
+  "indent": 2,
+  "latedef": true,
+  "newcap": true,
+  "noarg": true,
+  "quotmark": "single",
+  "regexp": true,
+  "undef": true,
+  "unused": true,
+  "strict": true,
+  "trailing": true,
+  "smarttabs": true
+}

--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
 'use strict';
-var crypto = require('crypto');
+
 var path = require('path');
 var gutil = require('gulp-util');
 var through = require('through2');
+var replaceInExtensions = ['.js', '.css', '.html'];
 
 function relPath(base, filePath) {
   var newPath = filePath.replace(base, '');
@@ -13,11 +14,11 @@ function relPath(base, filePath) {
   }
 }
 
-var plugin = function () {
+var plugin = function() {
   var renames = {};
   var cache = [];
 
-  return through.obj(function (file, enc, cb) {
+  return through.obj(function(file, enc, cb) {
     if (file.isNull()) {
       this.push(file);
       return cb();
@@ -28,28 +29,33 @@ var plugin = function () {
       return cb();
     }
 
+    // Collect renames from reved files.
     if (file.revOrigPath) {
       renames[relPath(file.revOrigBase, file.revOrigPath)] = relPath(file.base, file.path);
-
-      // Assume renamed files don't need any replacing and pass them through
-      // (we don't want to cache anything huge)
-      this.push(file);
-      cb();
-    } else {
-      cache.push(file);
-      cb();
     }
+
+    if (replaceInExtensions.indexOf(path.extname(file.path)) > -1) {
+      // Cache file to perform replacements in it later.
+      cache.push(file);
+    } else {
+      this.push(file);
+    }
+
+    cb();
   }, function(cb) {
-    // Once we have a full list of renames, search/replace in the non-renamed
+    // Once we have a full list of renames, search/replace in the cached
     // files and push them through.
     var file;
-    for (var i=0, ii=cache.length; i!=ii; i++) {
+    var contents;
+    for (var i = 0, ii = cache.length; i !== ii; i++) {
       file = cache[i];
-      for (path in renames) {
-        if (renames.hasOwnProperty(path)) {
-          file.contents = new Buffer(file.contents.toString().replace(path, renames[path]));
+      contents = file.contents.toString();
+      for (var rename in renames) {
+        if (renames.hasOwnProperty(rename)) {
+          contents = contents.replace(rename, renames[rename]);
         }
       }
+      file.contents = new Buffer(contents);
       this.push(file);
     }
 

--- a/test.js
+++ b/test.js
@@ -1,4 +1,7 @@
 'use strict';
+
+/* global it */
+
 var assert = require('assert');
 var gutil = require('gulp-util');
 var filter = require('gulp-filter');
@@ -6,45 +9,61 @@ var rev = require('gulp-rev');
 var revReplace = require('./index');
 var path = require('path');
 
-it('should replace filenames of only reved files', function (cb) {
-  var cssFilter = filter("**/*.css");
+var svgFileBody = '<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg xmlns="http://www.w3.org/2000/svg"></svg>';
+var cssFileBody = '@font-face { font-family: \'test\'; src: url(\'/fonts/font.svg\'); }\nbody { color: red; }';
+var htmlFileBody = '<html><head><link rel="stylesheet" href="/css/style.css" /></head><body></body></html>';
 
-  var stream = cssFilter
+it('should replace filenames in .css and .html files', function (cb) {
+  var filesToRevFilter = filter(['**/*.css', '**/*.svg']);
+
+  var stream = filesToRevFilter
     .pipe(rev())
-    .pipe(cssFilter.restore())
+    .pipe(filesToRevFilter.restore())
     .pipe(revReplace());
 
   var fileCount = 0;
-  var unreplacedPattern = /style\.css/;
+  var unreplacedCSSFilePattern = /style\.css/;
+  var unreplacedSVGFilePattern = /font\.svg/;
   stream.on('data', function(file) {
     var contents = file.contents.toString();
+    var extension = path.extname(file.path);
 
-    if (file.path.substr(-4) == 'html') {
+    if (extension === '.html') {
       assert(
-        !unreplacedPattern.test(contents),
-        "The renamed file's name should be replaced"
+        !unreplacedCSSFilePattern.test(contents),
+        'The renamed CSS file\'s name should be replaced'
       );
-    } else if (file.path.substr(-3) == 'css') {
+    } else if (extension === '.css') {
       assert(
-        unreplacedPattern.test(contents),
-        "The renamed file should not be modified"
+        !unreplacedSVGFilePattern.test(contents),
+        'The renamed SVG file\'s name should be replaced'
+      );
+    } else if (extension === '.svg') {
+      assert(
+        contents === svgFileBody,
+        'The SVG file should not be modified'
       );
     }
 
     fileCount++;
   });
   stream.on('end', function() {
-    assert.equal(fileCount, 2, "Only two files should pass through the stream");
+    assert.equal(fileCount, 3, 'Only three files should pass through the stream');
     cb();
   });
 
-  cssFilter.write(new gutil.File({
+  filesToRevFilter.write(new gutil.File({
     path: 'css/style.css',
-    contents: new Buffer('/* filename: /css/style.css */ body { color: red; } ')
+    contents: new Buffer(cssFileBody)
   }));
-  cssFilter.write(new gutil.File({
+  filesToRevFilter.write(new gutil.File({
+    path: 'fonts/font.svg',
+    contents: new Buffer(svgFileBody)
+  }));
+  filesToRevFilter.write(new gutil.File({
     path: 'index.html',
-    contents: new Buffer('<html><head><link rel="stylesheet" href="/css/style.css" /></head><body></body></html>')
+    contents: new Buffer(htmlFileBody)
   }));
-  cssFilter.end();
+
+  filesToRevFilter.end();
 });


### PR DESCRIPTION
Often you need to perform replacements in reved files. For instance in CSS files to change background image path to revved one. Also recreation of Buffer in loop had a big performance hit, so it was also removed.
