### PR TITLE
Fix issue of not replacing non-canonical URIs (Issue #1) with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ gulp.task("index", function() {
 });
 ```
 
+## API
+
+### revReplace(options)
+
+#### options.canonicalUris
+Type: `boolean`
+
+Default: `true`
+
+Use canonical Uris when replacing filePaths, i.e. when working with filepaths
+with non forward slash (`/`) path separators we replace them with forward slash.
+
 ## Contributors
 
 Denis Parchenko

--- a/index.js
+++ b/index.js
@@ -14,9 +14,22 @@ function relPath(base, filePath) {
   }
 }
 
-var plugin = function() {
+var plugin = function(options) {
   var renames = {};
   var cache = [];
+
+  options = options || {};
+  if (options.canonicalUris === undefined) {
+    options.canonicalUris = true;
+  }
+
+  function fmtPath(base, filePath) {
+    var newPath = relPath(base, filePath);
+    if (path.sep !== '/' && options.canonicalUris) {
+      newPath = newPath.split(path.sep).join('/');
+    }
+    return newPath;
+  }
 
   return through.obj(function(file, enc, cb) {
     if (file.isNull()) {
@@ -31,7 +44,7 @@ var plugin = function() {
 
     // Collect renames from reved files.
     if (file.revOrigPath) {
-      renames[relPath(file.revOrigBase, file.revOrigPath)] = relPath(file.base, file.path);
+      renames[fmtPath(file.revOrigBase, file.revOrigPath)] = fmtPath(file.base, file.path);
     }
 
     if (replaceInExtensions.indexOf(path.extname(file.path)) > -1) {


### PR DESCRIPTION
This is the same issue as mentioned in Issue #1

I have extended the original test to confirm that it does **not** pass on Windows.

I implemented a configurable solution, which defaults to On, which replaces filepath separator to the canonical URI separator: the forward slash (`/`) (http://tools.ietf.org/html/rfc3986).

The reason to have it configurable is so if any users rely on the old behavior they can easily revert to that.

I also added a second test to ensure the option works in the non-default state as well.
