### PR TITLE
Replace all occurrences of filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ gulp.task("index", function() {
 ## Contributors
 
 Denis Parchenko
+Håkon K. Eide
 
 
 ## License

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ var plugin = function() {
       contents = file.contents.toString();
       for (var rename in renames) {
         if (renames.hasOwnProperty(rename)) {
-          contents = contents.replace(rename, renames[rename]);
+          contents = contents.split(rename).join(renames[rename]);
         }
       }
       file.contents = new Buffer(contents);

--- a/test.js
+++ b/test.js
@@ -11,7 +11,7 @@ var path = require('path');
 
 var svgFileBody = '<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg xmlns="http://www.w3.org/2000/svg"></svg>';
 var cssFileBody = '@font-face { font-family: \'test\'; src: url(\'/fonts/font.svg\'); }\nbody { color: red; }';
-var htmlFileBody = '<html><head><link rel="stylesheet" href="/css/style.css" /></head><body></body></html>';
+var htmlFileBody = '<html><head><link rel="stylesheet" href="/css/style.css" /><link rel="stylesheet" href="/css/style.css" /></head><body></body></html>';
 
 it('should replace filenames in .css and .html files', function (cb) {
   var filesToRevFilter = filter(['**/*.css', '**/*.svg']);


### PR DESCRIPTION
Replace all occurrences of filename, not just the first one.

The approach used is faster than using regexp and safe against filenames containing regexp meta characters. 

Run [this](http://jsperf.com/replace-all-vs-split-join) in Chrome to see a performance comparison
