### PR TITLE
Read JSON manifest files

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ Default: `['.js', '.css', '.html', '.hbs']`
 
 Only substitute in new filenames in files of these types.
 
+#### options.manifest
+Type: `Stream` (e.g., `gulp.src()`)
+
+Read JSON manifests written out by `rev`. Allows replacing filenames that were
+`rev`ed prior to the current task.
+
 ## Contributors
 
 - Chad Jablonski

--- a/package.json
+++ b/package.json
@@ -29,8 +29,9 @@
     "gulp-util": "~2.2.14"
   },
   "devDependencies": {
-    "mocha": "~1.18.2",
+    "event-stream": "^3.1.7",
+    "gulp-filter": "~0.4.0",
     "gulp-rev": "~0.3.2",
-    "gulp-filter": "~0.4.0"
+    "mocha": "~1.18.2"
   }
 }


### PR DESCRIPTION
This pr adds a `manifest` option that allows a user to specify JSON manifest files produced by `rev`. Usage example:

```javascript
gulp.src('index.html')
  .pipe(revReplace({manifest: gulp.src('rev-manifest.json')}))
  .pipe(gulp.dest('build'));
```

The rationale for the addition is that in larger projects it's common to process files in separate tasks, or even incrementally. In such cases there are no `.revOrig*` properties for gulp-rev-replace to read in the stream, but there are manifest files that contain that same information.

Includes a test and readme update. Let me know if there's anything stylistically you don't like.