### PR TITLE
Added prefix support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ Default: `['.js', '.css', '.html', '.hbs']`
 
 Only substitute in new filenames in files of these types.
 
+#### options.prefix
+Type: `string`
+
+Default: ``
+
+Add the prefix string to each replacement.  
+
 ## Contributors
 
 - Chad Jablonski

--- a/index.js
+++ b/index.js
@@ -22,6 +22,8 @@ var plugin = function(options) {
     options.canonicalUris = true;
   }
 
+  options.prefix = options.prefix || '';
+
   options.replaceInExtensions = options.replaceInExtensions || ['.js', '.css', '.html', '.hbs'];
 
   function fmtPath(base, filePath) {
@@ -45,7 +47,7 @@ var plugin = function(options) {
 
     // Collect renames from reved files.
     if (file.revOrigPath) {
-      renames[fmtPath(file.revOrigBase, file.revOrigPath)] = fmtPath(file.base, file.path);
+      renames[fmtPath(file.revOrigBase, file.revOrigPath)] = options.prefix + fmtPath(file.base, file.path);
     }
 
     if (options.replaceInExtensions.indexOf(path.extname(file.path)) > -1) {
@@ -68,6 +70,9 @@ var plugin = function(options) {
         if (renames.hasOwnProperty(rename)) {
           contents = contents.split(rename).join(renames[rename]);
         }
+      }
+      if (options.prefix) {
+        contents = contents.split('/' + options.prefix).join(options.prefix + '/');
       }
       file.contents = new Buffer(contents);
       this.push(file);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-rev-replace",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Rewrite occurences of filenames which have been renamed by gulp-rev",
   "main": "index.js",
   "repository": "jamesknelson/gulp-rev-replace",


### PR DESCRIPTION
This PR adds `prefix` option that allows the user to add custom prefix to every replaced file name e.g. CDN url.

Example usage:
```js
gulp.src('index.html')
  .pipe(revReplace({prefix: 'http://example.com'})
  .pipe(gulp.dest('build'));
```