### PR TITLE
Replace longest strings first

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ function plugin(options) {
   var cache = [];
 
   options = options || {};
-  if (options.canonicalUris === undefined) {
+
+  if (!options.canonicalUris) {
     options.canonicalUris = true;
   }
 

--- a/index.js
+++ b/index.js
@@ -6,15 +6,6 @@ var path = require('path');
 var gutil = require('gulp-util');
 var through = require('through2');
 
-function relPath(base, filePath) {
-  var newPath = filePath.replace(base, '');
-  if (filePath !== newPath && newPath[0] === path.sep) {
-    return newPath.substr(1);
-  } else {
-    return newPath;
-  }
-}
-
 function plugin(options) {
   var renames = {};
   var cache = [];
@@ -27,10 +18,12 @@ function plugin(options) {
   options.replaceInExtensions = options.replaceInExtensions || ['.js', '.css', '.html', '.hbs'];
 
   function fmtPath(base, filePath) {
-    var newPath = relPath(base, filePath);
+    var newPath = path.relative(base, filePath);
+
     if (path.sep !== '/' && options.canonicalUris) {
       newPath = newPath.split(path.sep).join('/');
     }
+
     return newPath;
   }
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+module.exports = plugin;
+
 var path = require('path');
 var gutil = require('gulp-util');
 var through = require('through2');
@@ -13,7 +15,7 @@ function relPath(base, filePath) {
   }
 }
 
-var plugin = function(options) {
+function plugin(options) {
   var renames = {};
   var cache = [];
 
@@ -75,6 +77,4 @@ var plugin = function(options) {
 
     cb();
   });
-};
-
-module.exports = plugin;
+}

--- a/index.js
+++ b/index.js
@@ -18,16 +18,6 @@ function plugin(options) {
 
   options.replaceInExtensions = options.replaceInExtensions || ['.js', '.css', '.html', '.hbs'];
 
-  function fmtPath(base, filePath) {
-    var newPath = path.relative(base, filePath);
-
-    if (path.sep !== '/' && options.canonicalUris) {
-      newPath = newPath.split(path.sep).join('/');
-    }
-
-    return newPath;
-  }
-
   return through.obj(function(file, enc, cb) {
     if (file.isNull()) {
       this.push(file);
@@ -71,4 +61,14 @@ function plugin(options) {
 
     cb();
   });
+
+  function fmtPath(base, filePath) {
+    var newPath = path.relative(base, filePath);
+
+    if (path.sep !== '/' && options.canonicalUris) {
+      newPath = newPath.split(path.sep).join('/');
+    }
+
+    return newPath;
+  }
 }

--- a/test.js
+++ b/test.js
@@ -148,3 +148,43 @@ it('should not canonicalize URIs when option is off', function (cb) {
 
   filesToRevFilter.end();
 });
+
+it('should stop at first longest replace', function(cb) {
+  var jsFileBody = 'var loadFile = "nopestyle.css"';
+  var replacedJsFileBody = 'var loadFile = "nopestyle-19269897.css"';
+
+  var filesToRevFilter = filter(['**/*.css']);
+
+  var stream = filesToRevFilter
+    .pipe(rev())
+    .pipe(filesToRevFilter.restore())
+    .pipe(revReplace({canonicalUris: false}));
+
+  stream.on('data', function(file) {
+    if (file.path === 'script.js') {
+      assert.equal(
+        file.contents.toString(),
+        replacedJsFileBody,
+        'It should have replaced using the longest string match (nopestyle)'
+      );
+    }
+  });
+  stream.on('end', function() {
+    cb();
+  });
+
+  filesToRevFilter.write(new gutil.File({
+    path: 'style.css',
+    contents: new Buffer(cssFileBody)
+  }));
+  filesToRevFilter.write(new gutil.File({
+    path: 'nopestyle.css',
+    contents: new Buffer('boooooo')
+  }));
+  filesToRevFilter.write(new gutil.File({
+    path: 'script.js',
+    contents: new Buffer(jsFileBody)
+  }));
+
+  filesToRevFilter.end();
+});


### PR DESCRIPTION
Hi,

This PR consist of a bux fixing and some minor refactoring. 

The encoutered bug:

file.js:
```js
var loadFile = "nopestyle.css";
```

style.css:
```css
body {}
```

nopestyle.css:
```css
html{}
```

Using gulp-rev-replace with this setup, you will endup with `file.js` being replaced with the reved version of `style.css` because the match is not
done on the longest string, it was done on random string length based on the order files are pushed into the gulp stream.

I hope my explanation is clear, you can have a look at the newly created tests if not.

This is not the "perfect" solution but it's still sufficient.

Let met know @jamesknelson 