### PR TITLE
Fix `byLongestUnreved` behavior

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 'use strict';
 
-module.exports = plugin;
+module.exports = {
+  plugin: plugin,
+  byLongestUnreved: byLongestUnreved
+};
 
 var path = require('path');
 var gutil = require('gulp-util');
@@ -84,5 +87,5 @@ function plugin(options) {
 }
 
 function byLongestUnreved(a, b) {
-  return a.unreved.length < b.unreved.length;
+  return b.unreved.length - a.unreved.length;
 }

--- a/index.js
+++ b/index.js
@@ -1,13 +1,12 @@
 'use strict';
 
-module.exports = {
-  plugin: plugin,
-  byLongestUnreved: byLongestUnreved
-};
+module.exports = plugin;
 
 var path = require('path');
 var gutil = require('gulp-util');
 var through = require('through2');
+
+var utils = require('./utils');
 
 function plugin(options) {
   var renames = [];
@@ -54,7 +53,7 @@ function plugin(options) {
   }, function replaceInFiles(cb) {
     var stream = this;
 
-    renames = renames.sort(byLongestUnreved);
+    renames = renames.sort(utils.byLongestUnreved);
 
     // Once we have a full list of renames, search/replace in the cached
     // files and push them through.
@@ -84,8 +83,4 @@ function plugin(options) {
 
     return newPath;
   }
-}
-
-function byLongestUnreved(a, b) {
-  return b.unreved.length - a.unreved.length;
 }

--- a/test.js
+++ b/test.js
@@ -3,12 +3,13 @@
 /* global it */
 
 var assert = require('assert');
-var gutil = require('gulp-util');
 var filter = require('gulp-filter');
-var rev = require('gulp-rev');
-var revReplace = require('./index').plugin;
-var byLongest = require('./index').byLongestUnreved;
+var gutil = require('gulp-util');
 var path = require('path');
+var rev = require('gulp-rev');
+
+var revReplace = require('./index');
+var utils = require('./utils');
 
 var svgFileBody   = '<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg xmlns="http://www.w3.org/2000/svg"></svg>';
 var cssFileBody   = '@font-face { font-family: \'test\'; src: url(\'/fonts/font.svg\'); }\nbody { color: red; }';
@@ -226,120 +227,122 @@ it('should stop at first longest replace', function(cb) {
   filesToRevFilter.end();
 });
 
-it('should arrange renames from longest to shortest', function() {
-  var renames = [{
-    unreved: 'data/favicon.ico',
-    reved: 'data/favicon-15d0f308.ico'
-  }, {
-    unreved: 'fonts/FontAwesome.otf',
-    reved: 'fonts/FontAwesome-0b462f5c.otf'
-  }, {
-    unreved: 'fonts/fontawesome-webfont.eot',
-    reved: 'fonts/fontawesome-webfont-f7c2b4b7.eot'
-  }, {
-    unreved: 'fonts/fontawesome-webfont.svg',
-    reved: 'fonts/fontawesome-webfont-29800836.svg'
-  }, {
-    unreved: 'fonts/fontawesome-webfont.ttf',
-    reved: 'fonts/fontawesome-webfont-706450d7.ttf'
-  }, {
-    unreved: 'fonts/fontawesome-webfont.woff',
-    reved: 'fonts/fontawesome-webfont-d9ee23d5.woff'
-  }, {
-    unreved: 'fonts/fontawesome-webfont.woff2',
-    reved: 'fonts/fontawesome-webfont-97493d3f.woff2'
-  }, {
-    unreved: 'fonts/glyphicons-halflings-regular.eot',
-    reved: 'fonts/glyphicons-halflings-regular-f4769f9b.eot'
-  }, {
-    unreved: 'fonts/glyphicons-halflings-regular.svg',
-    reved: 'fonts/glyphicons-halflings-regular-89889688.svg'
-  }, {
-    unreved: 'fonts/glyphicons-halflings-regular.ttf',
-    reved: 'fonts/glyphicons-halflings-regular-e18bbf61.ttf'
-  }, {
-    unreved: 'fonts/glyphicons-halflings-regular.woff',
-    reved: 'fonts/glyphicons-halflings-regular-fa277232.woff'
-  }, {
-    unreved: 'fonts/glyphicons-halflings-regular.woff2',
-    reved: 'fonts/glyphicons-halflings-regular-448c34a5.woff2'
-  }, {
-    unreved: 'images/busy-indicator-lg-dark.gif',
-    reved: 'images/busy-indicator-lg-dark-8f372b90.gif'
-  }, {
-    unreved: 'images/busy-indicator-lg-light.gif',
-    reved: 'images/busy-indicator-lg-light-25050875.gif'
-  }, {
-    unreved: 'images/busy-indicator-sm-light.gif',
-    reved: 'images/busy-indicator-sm-light-b464283c.gif'
-  }, {
-    unreved: 'images/footer-logo.png',
-    reved: 'images/footer-logo-df3d73ed.png'
-  }, {
-    unreved: 'images/icon-progress-indicator.png',
-    reved: 'images/icon-progress-indicator-b342c570.png'
-  }, {
-    unreved: 'images/scripps-swirl.png',
-    reved: 'images/scripps-swirl-65b0319e.png'
-  }, {
-    unreved: 'images/sprite.png',
-    reved: 'images/sprite-9e275087.png'
-  }, {
-    unreved: 'images/sprite_2x.png',
-    reved: 'images/sprite_2x-c7af344b.png'
-  }, {
-    unreved: 'scripts/app.js', reved: 'scripts/app-137924b0.js'
-  }, {
-    unreved: 'styles/app.css', reved: 'styles/app-4858235a.css'
-  }, {
-    unreved: 'env/deploy/features.json',
-    reved: 'env/deploy/features-2a501331.json'
-  }];
+describe('utils.byLongestUnreved', function() {
+  it('should arrange renames from longest to shortest', function() {
+    var renames = [{
+      unreved: 'data/favicon.ico',
+      reved: 'data/favicon-15d0f308.ico'
+    }, {
+      unreved: 'fonts/FontAwesome.otf',
+      reved: 'fonts/FontAwesome-0b462f5c.otf'
+    }, {
+      unreved: 'fonts/fontawesome-webfont.eot',
+      reved: 'fonts/fontawesome-webfont-f7c2b4b7.eot'
+    }, {
+      unreved: 'fonts/fontawesome-webfont.svg',
+      reved: 'fonts/fontawesome-webfont-29800836.svg'
+    }, {
+      unreved: 'fonts/fontawesome-webfont.ttf',
+      reved: 'fonts/fontawesome-webfont-706450d7.ttf'
+    }, {
+      unreved: 'fonts/fontawesome-webfont.woff',
+      reved: 'fonts/fontawesome-webfont-d9ee23d5.woff'
+    }, {
+      unreved: 'fonts/fontawesome-webfont.woff2',
+      reved: 'fonts/fontawesome-webfont-97493d3f.woff2'
+    }, {
+      unreved: 'fonts/glyphicons-halflings-regular.eot',
+      reved: 'fonts/glyphicons-halflings-regular-f4769f9b.eot'
+    }, {
+      unreved: 'fonts/glyphicons-halflings-regular.svg',
+      reved: 'fonts/glyphicons-halflings-regular-89889688.svg'
+    }, {
+      unreved: 'fonts/glyphicons-halflings-regular.ttf',
+      reved: 'fonts/glyphicons-halflings-regular-e18bbf61.ttf'
+    }, {
+      unreved: 'fonts/glyphicons-halflings-regular.woff',
+      reved: 'fonts/glyphicons-halflings-regular-fa277232.woff'
+    }, {
+      unreved: 'fonts/glyphicons-halflings-regular.woff2',
+      reved: 'fonts/glyphicons-halflings-regular-448c34a5.woff2'
+    }, {
+      unreved: 'images/busy-indicator-lg-dark.gif',
+      reved: 'images/busy-indicator-lg-dark-8f372b90.gif'
+    }, {
+      unreved: 'images/busy-indicator-lg-light.gif',
+      reved: 'images/busy-indicator-lg-light-25050875.gif'
+    }, {
+      unreved: 'images/busy-indicator-sm-light.gif',
+      reved: 'images/busy-indicator-sm-light-b464283c.gif'
+    }, {
+      unreved: 'images/footer-logo.png',
+      reved: 'images/footer-logo-df3d73ed.png'
+    }, {
+      unreved: 'images/icon-progress-indicator.png',
+      reved: 'images/icon-progress-indicator-b342c570.png'
+    }, {
+      unreved: 'images/scripps-swirl.png',
+      reved: 'images/scripps-swirl-65b0319e.png'
+    }, {
+      unreved: 'images/sprite.png',
+      reved: 'images/sprite-9e275087.png'
+    }, {
+      unreved: 'images/sprite_2x.png',
+      reved: 'images/sprite_2x-c7af344b.png'
+    }, {
+      unreved: 'scripts/app.js', reved: 'scripts/app-137924b0.js'
+    }, {
+      unreved: 'styles/app.css', reved: 'styles/app-4858235a.css'
+    }, {
+      unreved: 'env/deploy/features.json',
+      reved: 'env/deploy/features-2a501331.json'
+    }];
 
-  var expected = [ { unreved: 'fonts/glyphicons-halflings-regular.woff2',
-    reved: 'fonts/glyphicons-halflings-regular-448c34a5.woff2' },
-  { unreved: 'fonts/glyphicons-halflings-regular.woff',
-    reved: 'fonts/glyphicons-halflings-regular-fa277232.woff' },
-  { unreved: 'fonts/glyphicons-halflings-regular.svg',
-    reved: 'fonts/glyphicons-halflings-regular-89889688.svg' },
-  { unreved: 'fonts/glyphicons-halflings-regular.ttf',
-    reved: 'fonts/glyphicons-halflings-regular-e18bbf61.ttf' },
-  { unreved: 'fonts/glyphicons-halflings-regular.eot',
-    reved: 'fonts/glyphicons-halflings-regular-f4769f9b.eot' },
-  { unreved: 'images/busy-indicator-lg-light.gif',
-    reved: 'images/busy-indicator-lg-light-25050875.gif' },
-  { unreved: 'images/busy-indicator-sm-light.gif',
-    reved: 'images/busy-indicator-sm-light-b464283c.gif' },
-  { unreved: 'images/icon-progress-indicator.png',
-    reved: 'images/icon-progress-indicator-b342c570.png' },
-  { unreved: 'images/busy-indicator-lg-dark.gif',
-    reved: 'images/busy-indicator-lg-dark-8f372b90.gif' },
-  { unreved: 'fonts/fontawesome-webfont.woff2',
-    reved: 'fonts/fontawesome-webfont-97493d3f.woff2' },
-  { unreved: 'fonts/fontawesome-webfont.woff',
-    reved: 'fonts/fontawesome-webfont-d9ee23d5.woff' },
-  { unreved: 'fonts/fontawesome-webfont.eot',
-    reved: 'fonts/fontawesome-webfont-f7c2b4b7.eot' },
-  { unreved: 'fonts/fontawesome-webfont.ttf',
-    reved: 'fonts/fontawesome-webfont-706450d7.ttf' },
-  { unreved: 'fonts/fontawesome-webfont.svg',
-    reved: 'fonts/fontawesome-webfont-29800836.svg' },
-  { unreved: 'env/deploy/features.json',
-    reved: 'env/deploy/features-2a501331.json' },
-  { unreved: 'images/scripps-swirl.png',
-    reved: 'images/scripps-swirl-65b0319e.png' },
-  { unreved: 'images/footer-logo.png',
-    reved: 'images/footer-logo-df3d73ed.png' },
-  { unreved: 'fonts/FontAwesome.otf',
-    reved: 'fonts/FontAwesome-0b462f5c.otf' },
-  { unreved: 'images/sprite_2x.png',
-    reved: 'images/sprite_2x-c7af344b.png' },
-  { unreved: 'images/sprite.png',
-    reved: 'images/sprite-9e275087.png' },
-  { unreved: 'data/favicon.ico',
-    reved: 'data/favicon-15d0f308.ico' },
-  { unreved: 'scripts/app.js', reved: 'scripts/app-137924b0.js' },
-  { unreved: 'styles/app.css', reved: 'styles/app-4858235a.css' } ];
+    var expected = [ { unreved: 'fonts/glyphicons-halflings-regular.woff2',
+      reved: 'fonts/glyphicons-halflings-regular-448c34a5.woff2' },
+    { unreved: 'fonts/glyphicons-halflings-regular.woff',
+      reved: 'fonts/glyphicons-halflings-regular-fa277232.woff' },
+    { unreved: 'fonts/glyphicons-halflings-regular.svg',
+      reved: 'fonts/glyphicons-halflings-regular-89889688.svg' },
+    { unreved: 'fonts/glyphicons-halflings-regular.ttf',
+      reved: 'fonts/glyphicons-halflings-regular-e18bbf61.ttf' },
+    { unreved: 'fonts/glyphicons-halflings-regular.eot',
+      reved: 'fonts/glyphicons-halflings-regular-f4769f9b.eot' },
+    { unreved: 'images/busy-indicator-lg-light.gif',
+      reved: 'images/busy-indicator-lg-light-25050875.gif' },
+    { unreved: 'images/busy-indicator-sm-light.gif',
+      reved: 'images/busy-indicator-sm-light-b464283c.gif' },
+    { unreved: 'images/icon-progress-indicator.png',
+      reved: 'images/icon-progress-indicator-b342c570.png' },
+    { unreved: 'images/busy-indicator-lg-dark.gif',
+      reved: 'images/busy-indicator-lg-dark-8f372b90.gif' },
+    { unreved: 'fonts/fontawesome-webfont.woff2',
+      reved: 'fonts/fontawesome-webfont-97493d3f.woff2' },
+    { unreved: 'fonts/fontawesome-webfont.woff',
+      reved: 'fonts/fontawesome-webfont-d9ee23d5.woff' },
+    { unreved: 'fonts/fontawesome-webfont.eot',
+      reved: 'fonts/fontawesome-webfont-f7c2b4b7.eot' },
+    { unreved: 'fonts/fontawesome-webfont.ttf',
+      reved: 'fonts/fontawesome-webfont-706450d7.ttf' },
+    { unreved: 'fonts/fontawesome-webfont.svg',
+      reved: 'fonts/fontawesome-webfont-29800836.svg' },
+    { unreved: 'env/deploy/features.json',
+      reved: 'env/deploy/features-2a501331.json' },
+    { unreved: 'images/scripps-swirl.png',
+      reved: 'images/scripps-swirl-65b0319e.png' },
+    { unreved: 'images/footer-logo.png',
+      reved: 'images/footer-logo-df3d73ed.png' },
+    { unreved: 'fonts/FontAwesome.otf',
+      reved: 'fonts/FontAwesome-0b462f5c.otf' },
+    { unreved: 'images/sprite_2x.png',
+      reved: 'images/sprite_2x-c7af344b.png' },
+    { unreved: 'images/sprite.png',
+      reved: 'images/sprite-9e275087.png' },
+    { unreved: 'data/favicon.ico',
+      reved: 'data/favicon-15d0f308.ico' },
+    { unreved: 'scripts/app.js', reved: 'scripts/app-137924b0.js' },
+    { unreved: 'styles/app.css', reved: 'styles/app-4858235a.css' } ];
 
-  assert.deepEqual(renames.sort(byLongest), expected);
+    assert.deepEqual(renames.sort(utils.byLongestUnreved), expected);
+  });
 });

--- a/test.js
+++ b/test.js
@@ -298,50 +298,74 @@ describe('utils.byLongestUnreved', function() {
       reved: 'env/deploy/features-2a501331.json'
     }];
 
-    var expected = [ { unreved: 'fonts/glyphicons-halflings-regular.woff2',
-      reved: 'fonts/glyphicons-halflings-regular-448c34a5.woff2' },
-    { unreved: 'fonts/glyphicons-halflings-regular.woff',
-      reved: 'fonts/glyphicons-halflings-regular-fa277232.woff' },
-    { unreved: 'fonts/glyphicons-halflings-regular.svg',
-      reved: 'fonts/glyphicons-halflings-regular-89889688.svg' },
-    { unreved: 'fonts/glyphicons-halflings-regular.ttf',
-      reved: 'fonts/glyphicons-halflings-regular-e18bbf61.ttf' },
-    { unreved: 'fonts/glyphicons-halflings-regular.eot',
-      reved: 'fonts/glyphicons-halflings-regular-f4769f9b.eot' },
-    { unreved: 'images/busy-indicator-lg-light.gif',
-      reved: 'images/busy-indicator-lg-light-25050875.gif' },
-    { unreved: 'images/busy-indicator-sm-light.gif',
-      reved: 'images/busy-indicator-sm-light-b464283c.gif' },
-    { unreved: 'images/icon-progress-indicator.png',
-      reved: 'images/icon-progress-indicator-b342c570.png' },
-    { unreved: 'images/busy-indicator-lg-dark.gif',
-      reved: 'images/busy-indicator-lg-dark-8f372b90.gif' },
-    { unreved: 'fonts/fontawesome-webfont.woff2',
-      reved: 'fonts/fontawesome-webfont-97493d3f.woff2' },
-    { unreved: 'fonts/fontawesome-webfont.woff',
-      reved: 'fonts/fontawesome-webfont-d9ee23d5.woff' },
-    { unreved: 'fonts/fontawesome-webfont.eot',
-      reved: 'fonts/fontawesome-webfont-f7c2b4b7.eot' },
-    { unreved: 'fonts/fontawesome-webfont.ttf',
-      reved: 'fonts/fontawesome-webfont-706450d7.ttf' },
-    { unreved: 'fonts/fontawesome-webfont.svg',
-      reved: 'fonts/fontawesome-webfont-29800836.svg' },
-    { unreved: 'env/deploy/features.json',
-      reved: 'env/deploy/features-2a501331.json' },
-    { unreved: 'images/scripps-swirl.png',
-      reved: 'images/scripps-swirl-65b0319e.png' },
-    { unreved: 'images/footer-logo.png',
-      reved: 'images/footer-logo-df3d73ed.png' },
-    { unreved: 'fonts/FontAwesome.otf',
-      reved: 'fonts/FontAwesome-0b462f5c.otf' },
-    { unreved: 'images/sprite_2x.png',
-      reved: 'images/sprite_2x-c7af344b.png' },
-    { unreved: 'images/sprite.png',
-      reved: 'images/sprite-9e275087.png' },
-    { unreved: 'data/favicon.ico',
-      reved: 'data/favicon-15d0f308.ico' },
-    { unreved: 'scripts/app.js', reved: 'scripts/app-137924b0.js' },
-    { unreved: 'styles/app.css', reved: 'styles/app-4858235a.css' } ];
+    var expected = [{
+      unreved: 'fonts/glyphicons-halflings-regular.woff2',
+      reved: 'fonts/glyphicons-halflings-regular-448c34a5.woff2'
+    }, {
+      unreved: 'fonts/glyphicons-halflings-regular.woff',
+      reved: 'fonts/glyphicons-halflings-regular-fa277232.woff'
+    }, {
+      unreved: 'fonts/glyphicons-halflings-regular.svg',
+      reved: 'fonts/glyphicons-halflings-regular-89889688.svg'
+    }, {
+      unreved: 'fonts/glyphicons-halflings-regular.ttf',
+      reved: 'fonts/glyphicons-halflings-regular-e18bbf61.ttf'
+    }, {
+      unreved: 'fonts/glyphicons-halflings-regular.eot',
+      reved: 'fonts/glyphicons-halflings-regular-f4769f9b.eot'
+    }, {
+      unreved: 'images/busy-indicator-lg-light.gif',
+      reved: 'images/busy-indicator-lg-light-25050875.gif'
+    }, {
+      unreved: 'images/busy-indicator-sm-light.gif',
+      reved: 'images/busy-indicator-sm-light-b464283c.gif'
+    }, {
+      unreved: 'images/icon-progress-indicator.png',
+      reved: 'images/icon-progress-indicator-b342c570.png'
+    }, {
+      unreved: 'images/busy-indicator-lg-dark.gif',
+      reved: 'images/busy-indicator-lg-dark-8f372b90.gif'
+    }, {
+      unreved: 'fonts/fontawesome-webfont.woff2',
+      reved: 'fonts/fontawesome-webfont-97493d3f.woff2'
+    }, {
+      unreved: 'fonts/fontawesome-webfont.woff',
+      reved: 'fonts/fontawesome-webfont-d9ee23d5.woff'
+    }, {
+      unreved: 'fonts/fontawesome-webfont.eot',
+      reved: 'fonts/fontawesome-webfont-f7c2b4b7.eot'
+    }, {
+      unreved: 'fonts/fontawesome-webfont.ttf',
+      reved: 'fonts/fontawesome-webfont-706450d7.ttf'
+    }, {
+      unreved: 'fonts/fontawesome-webfont.svg',
+      reved: 'fonts/fontawesome-webfont-29800836.svg'
+    }, {
+      unreved: 'env/deploy/features.json',
+      reved: 'env/deploy/features-2a501331.json'
+    }, {
+      unreved: 'images/scripps-swirl.png',
+      reved: 'images/scripps-swirl-65b0319e.png'
+    }, {
+      unreved: 'images/footer-logo.png',
+      reved: 'images/footer-logo-df3d73ed.png'
+    }, {
+      unreved: 'fonts/FontAwesome.otf',
+      reved: 'fonts/FontAwesome-0b462f5c.otf'
+    }, {
+      unreved: 'images/sprite_2x.png',
+      reved: 'images/sprite_2x-c7af344b.png'
+    }, {
+      unreved: 'images/sprite.png',
+      reved: 'images/sprite-9e275087.png'
+    }, {
+      unreved: 'data/favicon.ico',
+      reved: 'data/favicon-15d0f308.ico'
+    }, {
+      unreved: 'scripts/app.js', reved: 'scripts/app-137924b0.js'
+    }, {
+      unreved: 'styles/app.css', reved: 'styles/app-4858235a.css'
+    }];
 
     assert.deepEqual(renames.sort(utils.byLongestUnreved), expected);
   });

--- a/test.js
+++ b/test.js
@@ -6,7 +6,8 @@ var assert = require('assert');
 var gutil = require('gulp-util');
 var filter = require('gulp-filter');
 var rev = require('gulp-rev');
-var revReplace = require('./index');
+var revReplace = require('./index').plugin;
+var byLongest = require('./index').byLongestUnreved;
 var path = require('path');
 
 var svgFileBody   = '<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg xmlns="http://www.w3.org/2000/svg"></svg>';
@@ -225,3 +226,120 @@ it('should stop at first longest replace', function(cb) {
   filesToRevFilter.end();
 });
 
+it('should arrange renames from longest to shortest', function() {
+  var renames = [{
+    unreved: 'data/favicon.ico',
+    reved: 'data/favicon-15d0f308.ico'
+  }, {
+    unreved: 'fonts/FontAwesome.otf',
+    reved: 'fonts/FontAwesome-0b462f5c.otf'
+  }, {
+    unreved: 'fonts/fontawesome-webfont.eot',
+    reved: 'fonts/fontawesome-webfont-f7c2b4b7.eot'
+  }, {
+    unreved: 'fonts/fontawesome-webfont.svg',
+    reved: 'fonts/fontawesome-webfont-29800836.svg'
+  }, {
+    unreved: 'fonts/fontawesome-webfont.ttf',
+    reved: 'fonts/fontawesome-webfont-706450d7.ttf'
+  }, {
+    unreved: 'fonts/fontawesome-webfont.woff',
+    reved: 'fonts/fontawesome-webfont-d9ee23d5.woff'
+  }, {
+    unreved: 'fonts/fontawesome-webfont.woff2',
+    reved: 'fonts/fontawesome-webfont-97493d3f.woff2'
+  }, {
+    unreved: 'fonts/glyphicons-halflings-regular.eot',
+    reved: 'fonts/glyphicons-halflings-regular-f4769f9b.eot'
+  }, {
+    unreved: 'fonts/glyphicons-halflings-regular.svg',
+    reved: 'fonts/glyphicons-halflings-regular-89889688.svg'
+  }, {
+    unreved: 'fonts/glyphicons-halflings-regular.ttf',
+    reved: 'fonts/glyphicons-halflings-regular-e18bbf61.ttf'
+  }, {
+    unreved: 'fonts/glyphicons-halflings-regular.woff',
+    reved: 'fonts/glyphicons-halflings-regular-fa277232.woff'
+  }, {
+    unreved: 'fonts/glyphicons-halflings-regular.woff2',
+    reved: 'fonts/glyphicons-halflings-regular-448c34a5.woff2'
+  }, {
+    unreved: 'images/busy-indicator-lg-dark.gif',
+    reved: 'images/busy-indicator-lg-dark-8f372b90.gif'
+  }, {
+    unreved: 'images/busy-indicator-lg-light.gif',
+    reved: 'images/busy-indicator-lg-light-25050875.gif'
+  }, {
+    unreved: 'images/busy-indicator-sm-light.gif',
+    reved: 'images/busy-indicator-sm-light-b464283c.gif'
+  }, {
+    unreved: 'images/footer-logo.png',
+    reved: 'images/footer-logo-df3d73ed.png'
+  }, {
+    unreved: 'images/icon-progress-indicator.png',
+    reved: 'images/icon-progress-indicator-b342c570.png'
+  }, {
+    unreved: 'images/scripps-swirl.png',
+    reved: 'images/scripps-swirl-65b0319e.png'
+  }, {
+    unreved: 'images/sprite.png',
+    reved: 'images/sprite-9e275087.png'
+  }, {
+    unreved: 'images/sprite_2x.png',
+    reved: 'images/sprite_2x-c7af344b.png'
+  }, {
+    unreved: 'scripts/app.js', reved: 'scripts/app-137924b0.js'
+  }, {
+    unreved: 'styles/app.css', reved: 'styles/app-4858235a.css'
+  }, {
+    unreved: 'env/deploy/features.json',
+    reved: 'env/deploy/features-2a501331.json'
+  }];
+
+  var expected = [ { unreved: 'fonts/glyphicons-halflings-regular.woff2',
+    reved: 'fonts/glyphicons-halflings-regular-448c34a5.woff2' },
+  { unreved: 'fonts/glyphicons-halflings-regular.woff',
+    reved: 'fonts/glyphicons-halflings-regular-fa277232.woff' },
+  { unreved: 'fonts/glyphicons-halflings-regular.svg',
+    reved: 'fonts/glyphicons-halflings-regular-89889688.svg' },
+  { unreved: 'fonts/glyphicons-halflings-regular.ttf',
+    reved: 'fonts/glyphicons-halflings-regular-e18bbf61.ttf' },
+  { unreved: 'fonts/glyphicons-halflings-regular.eot',
+    reved: 'fonts/glyphicons-halflings-regular-f4769f9b.eot' },
+  { unreved: 'images/busy-indicator-lg-light.gif',
+    reved: 'images/busy-indicator-lg-light-25050875.gif' },
+  { unreved: 'images/busy-indicator-sm-light.gif',
+    reved: 'images/busy-indicator-sm-light-b464283c.gif' },
+  { unreved: 'images/icon-progress-indicator.png',
+    reved: 'images/icon-progress-indicator-b342c570.png' },
+  { unreved: 'images/busy-indicator-lg-dark.gif',
+    reved: 'images/busy-indicator-lg-dark-8f372b90.gif' },
+  { unreved: 'fonts/fontawesome-webfont.woff2',
+    reved: 'fonts/fontawesome-webfont-97493d3f.woff2' },
+  { unreved: 'fonts/fontawesome-webfont.woff',
+    reved: 'fonts/fontawesome-webfont-d9ee23d5.woff' },
+  { unreved: 'fonts/fontawesome-webfont.eot',
+    reved: 'fonts/fontawesome-webfont-f7c2b4b7.eot' },
+  { unreved: 'fonts/fontawesome-webfont.ttf',
+    reved: 'fonts/fontawesome-webfont-706450d7.ttf' },
+  { unreved: 'fonts/fontawesome-webfont.svg',
+    reved: 'fonts/fontawesome-webfont-29800836.svg' },
+  { unreved: 'env/deploy/features.json',
+    reved: 'env/deploy/features-2a501331.json' },
+  { unreved: 'images/scripps-swirl.png',
+    reved: 'images/scripps-swirl-65b0319e.png' },
+  { unreved: 'images/footer-logo.png',
+    reved: 'images/footer-logo-df3d73ed.png' },
+  { unreved: 'fonts/FontAwesome.otf',
+    reved: 'fonts/FontAwesome-0b462f5c.otf' },
+  { unreved: 'images/sprite_2x.png',
+    reved: 'images/sprite_2x-c7af344b.png' },
+  { unreved: 'images/sprite.png',
+    reved: 'images/sprite-9e275087.png' },
+  { unreved: 'data/favicon.ico',
+    reved: 'data/favicon-15d0f308.ico' },
+  { unreved: 'scripts/app.js', reved: 'scripts/app-137924b0.js' },
+  { unreved: 'styles/app.css', reved: 'styles/app-4858235a.css' } ];
+
+  assert.deepEqual(renames.sort(byLongest), expected);
+});

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,9 @@
+'use strict';
+
+function byLongestUnreved(a, b) {
+  return b.unreved.length - a.unreved.length;
+}
+
+module.exports = {
+  byLongestUnreved: byLongestUnreved
+};


### PR DESCRIPTION
Fix the compare function according to JS spec: <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort>.

If you revert the comparison function to how it was before, the test fails:

```
function byLongestUnreved(a, b) {
  return a.unreved.length < b.unreved.length;
}
```