### PR TITLE
Invoke JSHint suring running of tests

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,6 @@
 {
   "node": true,
+  "mocha": true,
   "browser": false,
   "esnext": true,
   "bitwise": true,

--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 'use strict';
 
-module.exports = plugin;
-
 var path = require('path');
 var gutil = require('gulp-util');
 var through = require('through2');
@@ -107,3 +105,5 @@ function plugin(options) {
     return filePath;
   }
 }
+
+module.exports = plugin;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "repository": "jamesknelson/gulp-rev-replace",
   "scripts": {
+    "pretest": "jshint *.js",
     "test": "mocha"
   },
   "keywords": [
@@ -33,6 +34,7 @@
     "event-stream": "^3.1.7",
     "gulp-filter": "~0.4.0",
     "gulp-rev": "~0.3.2",
+    "jshint": "^2.6.0",
     "mocha": "~1.18.2"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,5 +1,3 @@
-/* global it describe */
-
 'use strict';
 
 var assert = require('assert');


### PR DESCRIPTION
I was thinking of contributing, and noticed that while you have a .jshintrc, it's never used during the build.

It still doesn't cleanly exit, even though I made a couple of changes (as you can probably see from Travis), but I'm unsure if you want to fix the errors or ignore them. Instead of spending time on it, I'll just wait for your input on it before making it pass. :smile: 