### PR TITLE
Add options to modify the name of the unreved/reved files before using them

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Type: `Stream` (e.g., `gulp.src()`)
 Read JSON manifests written out by `rev`. Allows replacing filenames that were
 `rev`ed prior to the current task.
 
-### options.modifyUnreved, options.modifyReved
+#### options.modifyUnreved, options.modifyReved
 Type: `Function`
 
 Modify the name of the unreved/reved files before using them. The filename is

--- a/README.md
+++ b/README.md
@@ -103,6 +103,38 @@ Type: `Stream` (e.g., `gulp.src()`)
 Read JSON manifests written out by `rev`. Allows replacing filenames that were
 `rev`ed prior to the current task.
 
+### options.modifyUnreved, options.modifyReved
+Type: `Function`
+
+Modify the name of the unreved/reved files before using them by using a
+function. The filename is passed to the function as the first argument.
+
+For example, if in your manifest you have:
+
+```js
+{"js/app.js.map": "js/app-98adc164.js.map"}
+```
+
+If you wanted to get rid of the `js/` path just for `.map` files (because they
+are sourcemaps and the references to them are relative, not absolute) you could
+do the following:
+
+```js
+function replaceJsIfMap(filename) {
+    if (filename.indexOf('.map') > -1) {
+        return filename.replace('js/', '');
+    }
+}
+
+return gulp.src(opt.distFolder + '**/*.js')
+    .pipe(revReplace({
+        manifest: manifest,
+        modifyUnreved: replaceJsIfMap,
+        modifyReved: replaceJsIfMap
+    }))
+    .pipe(gulp.dest(opt.distFolder));
+```
+
 ## Contributors
 
 - Chad Jablonski

--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ Read JSON manifests written out by `rev`. Allows replacing filenames that were
 ### options.modifyUnreved, options.modifyReved
 Type: `Function`
 
-Modify the name of the unreved/reved files before using them by using a
-function. The filename is passed to the function as the first argument.
+Modify the name of the unreved/reved files before using them. The filename is
+passed to the function as the first argument.
 
 For example, if in your manifest you have:
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ function replaceJsIfMap(filename) {
     if (filename.indexOf('.map') > -1) {
         return filename.replace('js/', '');
     }
+    return filename;
 }
 
 return gulp.src(opt.distFolder + '**/*.js')

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ return gulp.src(opt.distFolder + '**/*.js')
 - Majid Burney
 - Simon Ihmig
 - Vincent Voyer
+- Bradley Abrahams
 
 
 ## License

--- a/index.js
+++ b/index.js
@@ -79,7 +79,9 @@ function plugin(options) {
         var contents = file.contents.toString();
 
         renames.forEach(function replaceOnce(rename) {
-          contents = contents.split(rename.unreved).join(rename.reved);
+          var unreved = options.modifyUnreved ? options.modifyUnreved(rename.unreved) : rename.unreved;
+          var reved = options.modifyReved ? options.modifyReved(rename.reved) : rename.reved;
+          contents = contents.split(unreved).join(reved);
           if (options.prefix) {
             contents = contents.split('/' + options.prefix).join(options.prefix + '/');
           }


### PR DESCRIPTION
This PR adds two new options: `modifyReved` and `modifyUnreved`.

I have updated the README to explain in more detail what is happening here. There are only a few new lines of code so hopefully they should be fairly self-explanatory.