### PR TITLE
Expose file to `modifyReved`/`modifyUnreved`

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,8 +79,8 @@ function plugin(options) {
         var contents = file.contents.toString();
 
         renames.forEach(function replaceOnce(rename) {
-          var unreved = options.modifyUnreved ? options.modifyUnreved(rename.unreved) : rename.unreved;
-          var reved = options.modifyReved ? options.modifyReved(rename.reved) : rename.reved;
+          var unreved = options.modifyUnreved ? options.modifyUnreved(rename.unreved, file) : rename.unreved;
+          var reved = options.modifyReved ? options.modifyReved(rename.reved, file) : rename.reved;
           contents = contents.split(unreved).join(reved);
           if (options.prefix) {
             contents = contents.split('/' + options.prefix).join(options.prefix + '/');


### PR DESCRIPTION
Hi, I am writing a task to support replace relative path. Below is my code snippet:

```js
gulp.task('html', ['revision'], function () {
    var manifest = gulp.src('.tmp/rev-manifest.json');

    var srcPath = path.join(__dirname, 'app');
    var revReplaceOptions = {};
    revReplaceOptions.manifest = manifest;
    function modifyDistPath(distPath, file) {
        var fileRelativePath = path.relative(srcPath, file.path);
        var fileDirname = path.dirname(fileRelativePath);
        var distPathRelativePath = path.relative(fileDirname, distPath);
        if (/^../.test(distPathRelativePath)) {
            return distPathRelativePath
        }
        return distPath;
    }
    revReplaceOptions.modifyUnreved = modifyDistPath;
    revReplaceOptions.modifyReved = modifyDistPath;

    return gulp.src('app/**/*.html')
        .pipe($.revReplace(revReplaceOptions))
        .pipe(gulp.dest('dist'));
});
```

So I need the `file.path` as an argument to support the feature. The PR is to support this.