### PR TITLE
allow `options.canonicalUris` to be false

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function plugin(options) {
 
   options = options || {};
 
-  if (!options.canonicalUris) {
+  if (typeof options.canonicalUris === 'undefined') {
     options.canonicalUris = true;
   }
 


### PR DESCRIPTION
current logic always sets this value to true when it's falsey.