### PR TITLE
Allow for a custom replace function

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,36 @@ return gulp.src(opt.distFolder + '**/*.js')
     .pipe(gulp.dest(opt.distFolder));
 ```
 
+#### options.replacer
+Type: `Function`
+
+Default: `return contents.split(unreved).join(reved)`
+
+Use a custom method for replacing the file references. The function is provided
+with three arguments: the `contents` of the file being processed, the `unreved`
+filename whose references are being searched for, and the `reved` filename with
+which they should be replaced.
+Note that the `replacer` function is called after `modifyUnreved` and `modifyReved`
+have been applied.
+
+The function should return the new `contents`.
+
+For example if you only want to replace the reference if it's between (double)
+quotes, you could do the following:
+
+```js
+function replaceFn(contents, unreved, reved) {
+    return contents.replace(new RegExp('"' + unreved + '"', 'g'), '"' + reved + '"');
+}
+
+return gulp.src(opt.distFolder + '**/*.js')
+    .pipe(revReplace({
+        manifest: manifest,
+        replacer: replaceFn
+    }))
+    .pipe(gulp.dest(opt.distFolder));
+```
+
 ## Contributors
 
 - Chad Jablonski

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ function plugin(options) {
         renames.forEach(function replaceOnce(rename) {
           var unreved = options.modifyUnreved ? options.modifyUnreved(rename.unreved) : rename.unreved;
           var reved = options.modifyReved ? options.modifyReved(rename.reved) : rename.reved;
-          contents = contents.split(unreved).join(reved);
+          contents = options.replacer ? options.replacer(contents, unreved, reved) : contents.split(unreved).join(reved);
           if (options.prefix) {
             contents = contents.split('/' + options.prefix).join(options.prefix + '/');
           }


### PR DESCRIPTION
Adds a 'replacer' options which can be assigned a custom function that is
used to replace unreved references with the reved ones, instead of the
default `contents.split(unreved).join(reved)`.

This could also be a potential fix for the problem described in #47.